### PR TITLE
fix: use only console based on PEP587 on Python 3.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Rattler-build's artifacts are in `output` when not specifying anything.
 /output
+# Pixi's configuration
+.pixi

--- a/recipe/console.patch
+++ b/recipe/console.patch
@@ -1,0 +1,75 @@
+diff --git a/cx_Freeze/executable.py b/cx_Freeze/executable.py
+index b19b5055..a5de6cbe 100644
+--- a/cx_Freeze/executable.py
++++ b/cx_Freeze/executable.py
+@@ -11,7 +11,6 @@ from sysconfig import get_config_var
+ from typing import TYPE_CHECKING
+ 
+ from cx_Freeze._compat import (
+-    ABI_THREAD,
+     EXE_SUFFIX,
+     IS_MACOS,
+     IS_MINGW,
+@@ -75,14 +74,10 @@ class Executable:
+ 
+     @base.setter
+     def base(self, name: str | Path | None) -> None:
+-        # The default base is the legacy console, except for Python 3.13t and
+-        # Python 3.13 on macOS, that supports only the new console
++        # The default base is the legacy console, except for
++        # Python 3.13, that supports only the new console
+         version = sys.version_info[:2]
+-        if (
+-            version <= (3, 13)
+-            and ABI_THREAD == ""
+-            and not (IS_MACOS and version == (3, 13))
+-        ):
++        if version <= (3, 13):
+             name = name or "console_legacy"
+         else:
+             name = name or "console"
+diff --git a/setup.py b/setup.py
+index 7185a255..171b121b 100644
+--- a/setup.py
++++ b/setup.py
+@@ -285,11 +285,7 @@ def get_extensions() -> list[Extension]:
+             optional=optional,
+         )
+     ]
+-    if (
+-        version <= (3, 13)
+-        and abi_thread == ""
+-        and not (IS_MACOS and version == (3, 13))
+-    ):
++    if version <= (3, 13):
+         extensions += [
+             Extension(
+                 "cx_Freeze.bases.console_legacy",
+diff --git a/tests/test_executables.py b/tests/test_executables.py
+index cdba2c9d..7e65b0ef 100644
+--- a/tests/test_executables.py
++++ b/tests/test_executables.py
+@@ -12,10 +12,8 @@ from setuptools import Distribution
+ 
+ from cx_Freeze import Executable
+ from cx_Freeze._compat import (
+-    ABI_THREAD,
+     BUILD_EXE_DIR,
+     EXE_SUFFIX,
+-    IS_MACOS,
+     IS_MINGW,
+     IS_WINDOWS,
+ )
+@@ -242,11 +240,7 @@ TEST_VALID_PARAMETERS = [
+         ("icon.ico", "icon.icns", "icon.png", "icon.svg"),
+     ),
+ ]
+-if (
+-    sys.version_info[:2] <= (3, 13)
+-    and ABI_THREAD == ""
+-    and not (IS_MACOS and sys.version_info[:2] == (3, 13))
+-):
++if sys.version_info[:2] <= (3, 13):
+     TEST_VALID_PARAMETERS += [
+         ("base", None, "console_legacy-"),
+         ("base", "console_legacy", "console_legacy-"),

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,11 @@ package:
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|lower }}-{{ version }}.tar.gz
   sha256: 80e1f87bb152ed0f97f7c6435e0237d44aade99979927c4627771322a25d550d
+  patches:
+    - console.patch
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - cxfreeze = cx_Freeze.cli:main


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
